### PR TITLE
2021.4.0

### DIFF
--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2021.4.0
+
+- Changed snapshot date scheme `%Y-%m-%d %H-%M` to improve compatibility
+- Added `custom_prefix` Allows you to change the name prefixing the date of the snapshot, by default this is set to `Automated backup`
+- Added `friendly_name` Allows the snapshot to be renamed on the destination server to match the name in the Home Assistant UI
+- Upgraded Base to 9.1.6
+- Upgraded Home Assistant CLI to 4.11.3
+- Reformatted code
+
 # 2021.3.0
 
 - Upgraded Home Assistant CLI to 4.11.0

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgraded Base to 9.1.6
 - Upgraded Home Assistant CLI to 4.11.3
 - Reformatted code
+- Addresses issue #13
 
 # 2021.3.0
 

--- a/remote-backup/DOCS.md
+++ b/remote-backup/DOCS.md
@@ -2,6 +2,8 @@
 Below is an example configuration:
 ```yaml
 ssh_enabled: true
+friendly_name: true
+custom_prefix: Automated backup
 ssh_host: ip address
 ssh_port: 22
 ssh_user: username
@@ -18,11 +20,13 @@ rsync_password: ''
 # Options
 |Parameter|Required|Description|
 |---------|--------|-----------|
-|`ssh_enabled`|No|Allows you to disable or enable the SSH function
+|`ssh_enabled`|No|Allows you to disable or enable the SSH function|
+|`friendly_name`|Yes|Allows the snapshot to be renamed on the destination server to match the name in the Home Assistant UI|
+|`custom_prefix`|Yes|Allows you to change the name prefixing the date of the snapshot, by default this is set to `Automated backup`|
 |`ssh_host`|Yes|The hostname or IP address of the file server|
 |`ssh_port`|Yes|The port used for `SCP`|
 |`ssh_user`|Yes|The username used for `SCP`|
 |`ssh_key`|Yes|The filename of the SSH key, this must be located in the `ssl` directory of Home Assistant which can be accessed through SAMBA under the share name `ssl`|
 |`remote_directory`|Yes|The destination directory where the snapshots will be placed|
 |`zip_password`|No|If set then the backup will be contained in a password protected zip file|
-|`keep_local_backup`|No|Control how many local backups you want to preserve on the Home Assistant host. The default (`""`) is to keep no local backups created from this addon. To keep all backups set this to `all` then all local backups will be preserved. This can also be set with a number to preserve only the specified amount
+|`keep_local_backup`|No|Control how many local backups you want to preserve on the Home Assistant host. The default (`""`) is to keep no local backups created from this addon. To keep all backups set this to `all` then all local backups will be preserved. This can also be set with a number to preserve only the specified amount|

--- a/remote-backup/Dockerfile
+++ b/remote-backup/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache jq openssh-client zip sshpass rsync wget
 # Hass.io CLI
 ARG BUILD_ARCH
 ARG CLI_VERSION
-RUN wget -O /usr/bin/ha "https://github.com/home-assistant/cli/releases/download/4.11.0/ha_${BUILD_ARCH}" \
+RUN wget -O /usr/bin/ha "https://github.com/home-assistant/cli/releases/download/4.11.3/ha_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/ha
 
 # Copy data

--- a/remote-backup/build.json
+++ b/remote-backup/build.json
@@ -1,11 +1,11 @@
 {
     "squash": false,
     "build_from": {
-      "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.5",
-      "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.5",
-      "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.5",
-      "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.5",
-      "i386": "ghcr.io/hassio-addons/base/i386:9.1.5"
+      "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.6",
+      "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.6",
+      "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.6",
+      "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.6",
+      "i386": "ghcr.io/hassio-addons/base/i386:9.1.6"
     },
     "args": {}
   }

--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Remote Backup",
-  "version": "2021.3.0",
+  "version": "2021.4.0",
   "slug": "remote_backup",
   "description": "Automatically create and backup HA snapshots using SCP",
   "url": "https://github.com/ikifar2012/remote-backup-addon/blob/master/README.md",
@@ -19,6 +19,8 @@
   "map": ["config", "addons", "share", "ssl", "backup:rw"],
   "options": {
     "ssh_enabled": true,
+    "friendly_name": true,
+    "custom_prefix":"Automated backup",
     "ssh_host": "",
     "ssh_port": 22,
     "ssh_user": "",
@@ -34,6 +36,8 @@
   },
   "schema": {
     "ssh_enabled": "bool",
+    "friendly_name": "bool",
+    "custom_prefix":"str",
     "ssh_host": "str",
     "ssh_port": "int",
     "ssh_user": "str",


### PR DESCRIPTION
- Changed snapshot date scheme `%Y-%m-%d %H-%M` to improve compatibility
- Added `custom_prefix` Allows you to change the name prefixing the date of the snapshot, by default this is set to `Automated backup`
- Added `friendly_name` Allows the snapshot to be renamed on the destination server to match the name in the Home Assistant UI
- Upgraded Base to 9.1.6
- Upgraded Home Assistant CLI to 4.11.3
- Reformatted code
- Addresses issue #13