### PR TITLE
2022.7.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+text eol=lf

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,3 +29,10 @@ jobs:
             --target remote-backup \
             --docker-user ${{ secrets.DOCKERHUB_USERNAME }} \
             --docker-password ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 🚀 Dispatch Repository Updater update signal
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: ikifar2012/ha-addons
+          event-type: update
+          client-payload: '{"addon": "remote-backup"}'

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Updated HA CLI to version 4.18.0
 - Updated base image to version 12.2.1
 - Workaround issue [#45](https://github.com/ikifar2012/remote-backup-addon/issues/45)
+- Automate repository updates
+
+**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.5.1...2022.7.0
 
 # 2022.5.1
 

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2022.7.0
+
+- Updated HA CLI to version 4.18.0
+- Updated base image to version 12.2.1
+- Workaround issue [#45](https://github.com/ikifar2012/remote-backup-addon/issues/45)
+
 # 2022.5.1
 
 - Fix codenotary signature

--- a/remote-backup/Dockerfile
+++ b/remote-backup/Dockerfile
@@ -17,7 +17,7 @@ RUN curl https://rclone.org/install.sh | bash
 # Hass.io CLI
 ARG BUILD_ARCH
 ARG CLI_VERSION
-RUN wget -O /usr/bin/ha "https://github.com/home-assistant/cli/releases/download/4.17.0/ha_${BUILD_ARCH}" \
+RUN wget -O /usr/bin/ha "https://github.com/home-assistant/cli/releases/download/4.18.0/ha_${BUILD_ARCH}" \
     && chmod a+x /usr/bin/ha
 
 # Copy data

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -1,10 +1,10 @@
 squash: false
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.1.2
-  amd64: ghcr.io/hassio-addons/base/amd64:11.1.2
-  armhf: ghcr.io/hassio-addons/base/armhf:11.1.2
-  armv7: ghcr.io/hassio-addons/base/armv7:11.1.2
-  i386: ghcr.io/hassio-addons/base/i386:11.1.2
+  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.1
+  amd64: ghcr.io/hassio-addons/base/amd64:12.2.1
+  armhf: ghcr.io/hassio-addons/base/armhf:12.2.1
+  armv7: ghcr.io/hassio-addons/base/armv7:12.2.1
+  i386: ghcr.io/hassio-addons/base/i386:12.2.1
 codenotary:
   signer: cas@mathesonsteplock.ca
   base_image: codenotary@frenck.dev

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -1,5 +1,5 @@
 name: Remote Backup
-version: "2022.5.1"
+version: "2022.7.0"
 slug: remote_backup
 description: Automatically create and backup HA backups using SCP
 image: ikifar/remote-backup-{arch}

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -73,7 +73,7 @@ function create-local-backup {
     if [ -n "${EXCLUDE_ADDONS}" ] || [ -n "${EXCLUDE_FOLDERS}" ] ; then
         EXCLUDED_FOLDERS=$(echo "${EXCLUDE_FOLDERS}" | tr ',' '\n')
         EXCLUDED_ADDONS=$(echo "${EXCLUDE_ADDONS}" | tr ',' '\n')
-        if [ "$DEBUG" = true ] ; then
+        if [ "${DEBUG}" = true ] ; then
             warn "\n Excluded folders: \n ${EXCLUDED_FOLDERS}\n---------------"
             warn "\n Excluded addons: \n ${EXCLUDED_ADDONS}\n----------------"
         fi
@@ -111,7 +111,7 @@ function create-local-backup {
 
 function copy-backup-to-remote {
 
-    if [ "$SSH_ENABLED" = true ] ; then
+    if [ "${SSH_ENABLED}" = true ] ; then
         cd /backup/ || exit
         if [[ -z "${ZIP_PASSWORD}" ]]; then
             warn "Copying ${slug}.tar to ${REMOTE_DIRECTORY} on ${SSH_HOST} using SCP"

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -1,4 +1,5 @@
 #!/command/with-contenv bashio
+# shellcheck shell=bash
 # parse inputs from options
 DEBUG=$(bashio::config 'debug')
 SSH_ENABLED=$(bashio::config "ssh_enabled")

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/command/with-contenv bashio
 # parse inputs from options
 DEBUG=$(bashio::config 'debug')
 SSH_ENABLED=$(bashio::config "ssh_enabled")
@@ -67,7 +67,7 @@ function create-local-backup {
     FOLDERS=""
     ADDONS=""
     BASE_FOLDERS="addons/local homeassistant media share ssl"
-    INSTALLED_ADDONS=$(bashio::addons.installed)
+    INSTALLED_ADDONS=$(bashio::supervisor.addons)
     name="${CUSTOM_PREFIX} $(date +'%Y-%m-%d %H-%M')"
     warn "Creating local backup: \"${name}\""
     if [ -n "${EXCLUDE_ADDONS}" ] || [ -n "${EXCLUDE_FOLDERS}" ] ; then


### PR DESCRIPTION
- Updated HA CLI to version 4.18.0
- Updated base image to version 12.2.1
- Workaround issue [#45](https://github.com/ikifar2012/remote-backup-addon/issues/45)
- Automate repository updates

**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.5.1...2022.7.0