### PR TITLE
enable rsync key-based authentication

### DIFF
--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -39,7 +39,7 @@ SSH_ID="/ssl/${SSH_KEY}"
 SSH_ID=$(echo -n "${SSH_ID}")
 function add-ssh-key {
 
-    if [ "${SSH_ENABLED}" = true ] ; then
+    if [ "${SSH_ENABLED}" = true ] || [ "${RSYNC_ENABLED}" = true ] ; then
         info "Adding SSH key"
         mkdir -p ~/.ssh
         cp "${SSH_ID}" "${HOME}"/.ssh/id_rsa
@@ -148,6 +148,8 @@ function rsync_folders {
         else
             FLAGS='-a'
         fi
+        info "Adding key of remote host ${RSYNC_HOST} to known hosts."
+        ssh-keyscan -t rsa ${RSYNC_HOST} >> ~/.ssh/known_hosts
         if [ -z "${RSYNC_EXCLUDE}" ]; then
             warn "Syncing /config"
              sshpass -p "${RSYNC_PASSWORD}" rsync ${FLAGS} --exclude '*.db-shm' --exclude '*.db-wal' --exclude '*.db' /config/ "${rsyncurl}/config/" --delete


### PR DESCRIPTION
This patch allows that also rsync works with key-based authentication