### PR TITLE
renamed and resorted configuration

### DIFF
--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -23,63 +23,59 @@ map:
   - share
   - ssl
   - backup:rw
+  
 options:
   debug: false
-  ssh_enabled: true
-  friendly_name: true
-  custom_prefix: Automated backup
-  ssh_host: ""
-  ssh_port: 22
-  ssh_user: ""
-  ssh_key: ""
-  ssh_host_key_algorithms: ""
-  exclude_folders: []
-  exclude_addons: []
-  remote_directory: ""
+  remote_host: ""
+  remote_port: 22
+  remote_user: ""
+  remote_password: ""
+  remote_key: ""
+  remote_host_key_algorithms: ""
+  backup_friendly_name: true
+  backup_custom_prefix: Automated backup
+  backup_exclude_folders: []
+  backup_exclude_addons: []
+  backup_keep_local: "all"
   backup_password: ""
-  keep_local_backup: "all"
+  ssh_enabled: true
+  ssh_remote_directory: ""
   rsync_enabled: false
-  rsync_host: ""
   rsync_rootfolder: hassio-sync
   rsync_exclude:
     - "/config/*.db-shm"
     - "/config/*.db-wal"
     - "/config/*.db"
-  rsync_user: ""
-  rsync_password: ""
   rclone_enabled: false
+  rclone_remote_directory: ""
   rclone_copy: false
   rclone_sync: false
   rclone_restore: false
-  rclone_remote: ""
-  rclone_remote_directory: ""
+
 schema:
   debug: bool?
-  ssh_enabled: bool?
-  friendly_name: bool?
-  custom_prefix: str?
-  ssh_host: str?
-  ssh_port: port?
-  ssh_user: str?
-  ssh_key: str?
-  ssh_host_key_algorithms: str?
-  exclude_folders:
+  remote_host: str
+  remote_port: port
+  remote_user: str
+  remote_password: str?
+  remote_key: str?  
+  remote_host_key_algorithms: str?
+  backup_friendly_name: bool?
+  backup_custom_prefix: str?
+  backup_exclude_folders:
     - match(^[A-Za-z0-9_\-\.\*\/\?\+\\]*$)?
-  exclude_addons:
+  backup_exclude_addons:
     - str?
-  remote_directory: str?
+  backup_keep_local: match(^(all|[+]?\d*)$)
   backup_password: str?
-  keep_local_backup: match(^(all|[+]?\d*)$)
-  rsync_enabled: bool?
-  rsync_host: str?
+  ssh_enabled: bool
+  ssh_remote_directory: str?
+  rsync_enabled: bool
   rsync_rootfolder: str?
   rsync_exclude:
     - match(^[A-Za-z0-9_\-\.\*\/\?\+\\]+$)
-  rsync_user: str?
-  rsync_password: str?
-  rclone_enabled: bool?
+  rclone_enabled: bool
+  rclone_remote_directory: str?
   rclone_copy: bool?
   rclone_sync: bool?
   rclone_restore: bool?
-  rclone_remote: str?
-  rclone_remote_directory: str?

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -113,7 +113,7 @@ function copy-backup-to-remote {
     if [ "${SSH_ENABLED}" = true ] ; then
         cd /backup/ || exit
             bashio::log.info "Copying ${slug}.tar to ${SSH_REMOTE_DIRECTORY} on ${REMOTE_HOST} using SCP"
-            scp -F "${HOME}/.ssh/config" "${slug}.tar" remote:"${SSH_REMOTE_DIRECTORY}"
+            scp -F "${HOME}/.ssh/config" "${slug}.tar" remote:"${SSH_REMOTE_DIRECTORY}/"
             bashio::log.info "Backup copied to ${SSH_REMOTE_DIRECTORY}/${slug}.tar on ${REMOTE_HOST}"
 
         if [ "${BACKUP_FRIENDLY_NAME}" = true ] ; then

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -1,25 +1,54 @@
 configuration:
   debug:
     name: Enable debugging
+  remote_host:
+    name: Remote host
+    description: The hostname or IP address of the remote server
+  remote_port:
+    name: Remote port
+    description: Port number of the remote server
+  remote_user:
+    name: Username
+    description: Username to be used for authentication with remote server
+  remote_password:
+    name: Password
+    description: Password to be used for authentication with remote server
+  remote_key:
+    name: SSH private key
+    description: SSH private key file to be used for authentication with remote server. This be located in the directory 'ssl' of Home Assistant.
+  remote_host_key_algorithms:
+    name: Host key algorithms
+    description: Can be used to enable further (legacy) algorithms for authentication  
+  backup_friendly_name:
+    name: Friendly name
+    description: Rename the backup on the destination server to match the name in the Home Assistant UI
+  backup_custom_prefix:
+    name: Custom backup name prefix
+  backup_exclude_folders:
+    name: Folder to exclude from backup
+  backup_exclude_addons:
+    name: Addon to exclude from backup
+    description: Give the addons slug which equals the addon hostname using '_' instead of '-', e.g. core-mariadb
+  backup_keep_local:
+    name: Local backups to keep
+    description: default is 'all', give a number for the last x backups to keep or empty to immediately remove created backups after copying.
+  backup_password:
+    name: Password for protected backup
   ssh_enabled:
     name: Enable SSH
     description: Copies Home Assistant backups to the remote server
-  friendly_name:
-    name: Friendly name
-    description: Rename the backup on the destination server to match the name in the Home Assistant UI
-  custom_prefix:
-    name: Custom backup name prefix
-  ssh_key:
-    name: SSH key
-    description: The filename of the SSH key, which must be located in the directory 'ssl' of Home Assistant.
-  exclude_folders:
-    name: Folder to exclude from backup
-  exclude_addons:
-    name: Addon to exclude from backup
-    description: Give the addons slug which equals the addon hostname using '_' instead of '-', e.g. core-mariadb
+  ssh_remote_directory:
+    name: SSH remote directory
+    description: Remote directory the backups are copied to
   rsync_enabled:
     name: Enable rsync
     description: Clones local folders to remote server (including backups)
+  rsync_rootfolder:
+    name: rsync root folder
+    description: Root folder to which Home Assistant directories are synchronized
   rsync_exclude:
-    name: Path patterns to exclude from sync
+    name: rsync path patterns to exclude from sync
     description: This feature uses the rsync --exclude scheme
+  rclone_enabled:
+    name: Enable rclone
+    description: Experimental!

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -25,10 +25,10 @@ configuration:
   backup_custom_prefix:
     name: Custom backup name prefix
   backup_exclude_folders:
-    name: Folder to exclude from backup
+    name: Folder to exclude from backup (valid options are addons/local, homeassistant, media, share, ssl)"
   backup_exclude_addons:
     name: Addon to exclude from backup
-    description: Give the addons slug which equals the addon hostname using '_' instead of '-', e.g. core-mariadb
+    description: Give the addons slug which equals the addon hostname using '_' instead of '-', e.g. core_mariadb
   backup_keep_local:
     name: Local backups to keep
     description: default is 'all', give a number for the last x backups to keep or empty to immediately remove created backups after copying.
@@ -39,7 +39,7 @@ configuration:
     description: Copies Home Assistant backups to the remote server
   ssh_remote_directory:
     name: SSH remote directory
-    description: Remote directory the backups are copied to
+    description: Remote directory the backups are copied to (path must exist)
   rsync_enabled:
     name: Enable rsync
     description: Clones local folders to remote server (including backups)


### PR DESCRIPTION
Quite a big change (for users):
- there is now only one identity and one remote host for all protocols
- added more configuration option descriptions
- the sorting is "general options" and then per protocol the "enable" and possible further configuration. I hope that makes usage simpler. Note: _documentation needs update!_

rsync and scp have been tested by me, rclone is missing.