### PR TITLE
Backup password fix

### DIFF
--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2022.9.1
+
+- Backup password fix #68
+
+**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.9.0...2022.9.1
+
 # 2022.9.0
 
 ## Please read before upgrading

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -1,5 +1,5 @@
 name: Remote Backup
-version: "2022.9.0"
+version: "2022.9.1"
 slug: remote_backup
 description: Automatically create and transfer HA backups using SFTP (SCP), rsync, or rclone (experimental)
 image: ikifar/remote-backup-{arch}

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -98,8 +98,14 @@ function create-local-backup {
     local -r backup_exclude_folders=$(bashio::config "backup_exclude_folders")
     local -r backup_exclude_addons=$(bashio::config "backup_exclude_addons")
     local -r base_folders="addons/local homeassistant media share ssl"
-    local data="{\"name\":\"${BACKUP_NAME}\", \"password\": \"$(bashio::config 'backup_password' '')\"}"
-
+    local -r backup_password=$(bashio::config "backup_password")
+    if bashio::config.has_value "${backup_password}"; then
+        bashio::log.info "Creating local backup with password."
+        local data="{\"name\":\"${BACKUP_NAME}\", \"password\": \"${backup_password}\"}"
+    else
+        bashio::log.warning "No password set, creating a local backup without password."
+        local data="{\"name\":\"${BACKUP_NAME}\"}"
+    fi
     if bashio::var.has_value "${backup_exclude_addons}" || bashio::var.has_value "${backup_exclude_folders}"; then
         bashio::log.info "Creating partial backup: \"${BACKUP_NAME}\""
 


### PR DESCRIPTION
Solves the issue #67 by checking whether or not a password is provided in the config before attempting to create an encrypted backup