### PR TITLE
2022.12.0

### DIFF
--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,8 +1,9 @@
 # 2022.12.0
 
-- Bump Base Image to 12.2.7
+- Bump Base Image to 13.0.0
 - extend connection debug messages #77
 - Logo #78
+- Add null option #83
 
 **Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.9.4...2022.12.0
 

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2022.12.0
+
+- Bump Base Image to 12.2.7
+- extend connection debug messages #77
+- Logo #78
+
+**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.9.4...2022.12.0
+
 # 2022.9.4
 
 - Message typo fix #73

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -1,10 +1,10 @@
 squash: false
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.7
-  amd64: ghcr.io/hassio-addons/base/amd64:12.2.7
-  armhf: ghcr.io/hassio-addons/base/armhf:12.2.7
-  armv7: ghcr.io/hassio-addons/base/armv7:12.2.7
-  i386: ghcr.io/hassio-addons/base/i386:12.2.7
+  aarch64: ghcr.io/hassio-addons/base/aarch64:13.0.0
+  amd64: ghcr.io/hassio-addons/base/amd64:13.0.0
+  armhf: ghcr.io/hassio-addons/base/armhf:13.0.0
+  armv7: ghcr.io/hassio-addons/base/armv7:13.0.0
+  i386: ghcr.io/hassio-addons/base/i386:13.0.0
 codenotary:
   signer: cas@mathesonsteplock.ca
   base_image: codenotary@frenck.dev

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -1,10 +1,10 @@
 squash: false
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.3
-  amd64: ghcr.io/hassio-addons/base/amd64:12.2.3
-  armhf: ghcr.io/hassio-addons/base/armhf:12.2.3
-  armv7: ghcr.io/hassio-addons/base/armv7:12.2.3
-  i386: ghcr.io/hassio-addons/base/i386:12.2.3
+  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.7
+  amd64: ghcr.io/hassio-addons/base/amd64:12.2.7
+  armhf: ghcr.io/hassio-addons/base/armhf:12.2.7
+  armv7: ghcr.io/hassio-addons/base/armv7:12.2.7
+  i386: ghcr.io/hassio-addons/base/i386:12.2.7
 codenotary:
   signer: cas@mathesonsteplock.ca
   base_image: codenotary@frenck.dev

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -56,7 +56,7 @@ schema:
     - match(^[A-Za-z0-9_\-\.\*\/\?\+\\ ]*$)?
   backup_exclude_addons:
     - str?
-  backup_keep_local: match(^(all|[+]?\d*)$)?
+  backup_keep_local: match(^(all|null|[+]?\d*)$)?
   backup_password: str?
   ssh_enabled: bool
   ssh_remote_directory: str?

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -1,5 +1,5 @@
 name: Remote Backup
-version: "2022.9.5"
+version: "2022.12.0"
 slug: remote_backup
 description: Automatically create and transfer HA backups using SFTP (SCP), rsync, or rclone (experimental)
 image: ikifar/remote-backup-{arch}

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -286,7 +286,7 @@ function clone-to-remote {
 }
 
 function delete-local-backup {
-    if bashio::config.equals "backup_keep_local" "all"; then
+    if bashio::config.equals "backup_keep_local" "all" || bashio::config.equals "backup_keep_local" "null"; then
         bashio::log.debug "Keep all backups."
         return "${__BASHIO_EXIT_OK}"
     fi


### PR DESCRIPTION
- Bump Base Image to 13.0.0
- extend connection debug messages #77
- Logo #78
- Add null option #83

**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2022.9.4...2022.12.0