### PR TITLE
Fix `scp: dest open` double quoting issue 

### DIFF
--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -179,7 +179,7 @@ function copy-backup-to-remote {
     bashio::log.info "Copying backup using SFTP/SCP."
     (
       sshpass -p "${REMOTE_PASSWORD}" \
-        scp ${DEBUG_FLAG:-} -s -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"${remote_directory}/${remote_name}.tar" || (
+        scp ${DEBUG_FLAG:-} -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"${remote_directory}/${remote_name}.tar" || (
         bashio::log.warning "SFTP transfer failed, falling back to SCP: $(sshpass_error $?)"
         sshpass -p "${REMOTE_PASSWORD}" \
           scp ${DEBUG_FLAG:-} -O -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"${remote_directory}/${remote_name}.tar" || (

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -124,7 +124,7 @@ function create-local-backup {
 
         local unformatted_folders="${base_folders}"
         local unformatted_addons=$(bashio::supervisor.addons)
-        
+
         if bashio::config.has_value "backup_exclude_folders"; then
             local -r backup_exclude_folders=$(bashio::config "backup_exclude_folders")
             bashio::log.notice "Excluded folder(s):\n${backup_exclude_folders}"
@@ -179,10 +179,10 @@ function copy-backup-to-remote {
     bashio::log.info "Copying backup using SFTP/SCP."
     (
       sshpass -p "${REMOTE_PASSWORD}" \
-        scp ${DEBUG_FLAG:-} -s -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"\"${remote_directory}/${remote_name}.tar\"" || (
+        scp ${DEBUG_FLAG:-} -s -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"${remote_directory}/${remote_name}.tar" || (
         bashio::log.warning "SFTP transfer failed, falling back to SCP: $(sshpass_error $?)"
         sshpass -p "${REMOTE_PASSWORD}" \
-          scp ${DEBUG_FLAG:-} -O -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"\"${remote_directory}/${remote_name}.tar\"" || (
+          scp ${DEBUG_FLAG:-} -O -F "${SSH_HOME}/config" "/backup/${SLUG}.tar" remote:"${remote_directory}/${remote_name}.tar" || (
             bashio::log.error "Error copying backup ${SLUG}.tar to ${remote_directory} on ${REMOTE_HOST}:  $(sshpass_error $?)"
             return "${__BASHIO_EXIT_NOK}"
         )


### PR DESCRIPTION
This PR it to fix the `scp: dest open` double quoting issue brought up by @SirGoodenough in issue #84 
In my testing I was able to get it to work using just a single set of double quotes around the remote it seems to work without the backslash and path's with spaces still work 