### PR TITLE
2023.12.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,6 @@ name: "Publish"
 
 on:
   workflow_dispatch:
-    branches:
-      - master
   release:
     types: [published]
 
@@ -21,14 +19,15 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish
         uses: home-assistant/builder@master
-        env:
-          CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
+        # env:
+        #   CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
         with:
           args: |
             --all \
             --target remote-backup \
             --docker-user ${{ secrets.DOCKERHUB_USERNAME }} \
-            --docker-password ${{ secrets.DOCKERHUB_TOKEN }}
+            --docker-password ${{ secrets.DOCKERHUB_TOKEN }} \
+            --cosign
       - name: 🚀 Dispatch Repository Updater update signal
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,8 +19,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish
         uses: home-assistant/builder@master
-        # env:
-        #   CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
         with:
           args: |
             --all \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,4 +17,4 @@ jobs:
             --all \
             --target remote-backup \
             --docker-hub ikifar \
-            - cosign
+            -- cosign

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,4 +16,5 @@ jobs:
             --test \
             --all \
             --target remote-backup \
-            --docker-hub ikifar
+            --docker-hub ikifar \
+            - cosign

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,4 +17,4 @@ jobs:
             --all \
             --target remote-backup \
             --docker-hub ikifar \
-            -- cosign
+            --cosign

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2023.12.0
+
+- ⬆️ Bump base image to 15.0.1 from 13.1.3
+- **Breaking Change** - Switch from `/ssl` to `addon_configs/3490a758_remote_backup` for config directory (migration should be automatic)
+- Temporarily disable `apparmor` to fix #119
+- Drop CodeNotary signing in favor of cosign
+
+**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2023.3.0...2023.12.0
+
 # 2023.3.0
 
 - Bump base image from 13.0.0 to 13.1.3

--- a/remote-backup/CHANGELOG.md
+++ b/remote-backup/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 # 2022.12.1
 
-- Fix `scp: dest open` double quoting issue #86 addresses #84 
+- Fix `scp: dest open` double quoting issue #86 addresses #84
 - Correct null behavior #85 addresses #81
 - Bump Base Image to 13.0.1
 

--- a/remote-backup/apparmor.txt
+++ b/remote-backup/apparmor.txt
@@ -1,18 +1,17 @@
 #include <tunables/global>
 
-profile ADDON_SLUG flags=(attach_disconnected,mediate_deleted) {
+profile remote_backup flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   # Capabilities
   file,
   signal (send) set=(kill,term,int,hup,cont),
+  network,
 
   # S6-Overlay
   /init ix,
   /bin/** ix,
-  /usr/bin/rsync ix,
-  /usr/bin/scp ix,
-  /usr/bin/rclone ix,
+  /usr/bin/** ix,
   /run/{s6,s6-rc*,service}/** ix,
   /package/** ix,
   /command/** ix,
@@ -28,4 +27,70 @@ profile ADDON_SLUG flags=(attach_disconnected,mediate_deleted) {
 
   # Access to options.json and other files within your addon
   /data/** rw,
+
+  # Start new profile for service
+  /run.sh cx -> run.sh,
+
+  profile run.sh flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+
+    # Capabilities
+    file,
+    signal (send) set=(kill,term,int,hup,cont),
+    network,
+
+    # Receive signals from S6-Overlay
+    signal (receive) peer=*_remote_backup_*, # <- Replace with your service name
+
+
+    # Access to options.json and other files within your addon
+    /data/** rw,
+
+    # Access to mapped volumes specified in config.json
+    /config/** rw,
+    /addons/** rw,
+    /share/** rw,
+    /ssl/** rw,
+    /backup/** rw,
+    /homeassistant_config/** rw,
+
+    # Access required for service functionality
+    /run.sh r,
+    /bin/bash rix,
+    /usr/bin/curl rix,
+    /bin/echo ix,
+    /etc/passwd r,
+    /dev/tty rw,
+  }
+  profile /usr/bin/curl flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+
+    # Capabilities
+    file,
+    signal (send) set=(kill,term,int,hup,cont),
+    network,
+
+    # Receive signals from S6-Overlay
+    signal (receive) peer=*_remote_backup_*, # <- Replace with your service name
+
+
+    # Access to options.json and other files within your addon
+    /data/** rw,
+
+    # Access to mapped volumes specified in config.json
+    /config/** rw,
+    /addons/** rw,
+    /share/** rw,
+    /ssl/** rw,
+    /backup/** rw,
+    /homeassistant_config/** rw,
+
+    # Access required for service functionality
+    /run.sh r,
+    /bin/bash rix,
+    /usr/bin/curl rix,
+    /bin/echo ix,
+    /etc/passwd r,
+    /dev/tty rw,
+  }
 }

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -5,6 +5,6 @@ build_from:
   armhf: ghcr.io/hassio-addons/base/armhf:14.3.3
   armv7: ghcr.io/hassio-addons/base/armv7:14.3.3
   i386: ghcr.io/hassio-addons/base/i386:14.3.3
-codenotary:
-  signer: cas@mathesonsteplock.ca
-  base_image: codenotary@frenck.dev
+cosign:
+  base_identity: https://github.com/hassio-addons/addon-base/.*
+  identity: https://github.com/ikifar2012/remote-backup-addon/.*

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -5,6 +5,3 @@ build_from:
   armhf: ghcr.io/hassio-addons/base/armhf:14.3.3
   armv7: ghcr.io/hassio-addons/base/armv7:14.3.3
   i386: ghcr.io/hassio-addons/base/i386:14.3.3
-cosign:
-  base_identity: https://github.com/hassio-addons/addon-base/.*
-  identity: https://github.com/ikifar2012/remote-backup-addon/.*

--- a/remote-backup/build.yaml
+++ b/remote-backup/build.yaml
@@ -1,7 +1,7 @@
 squash: false
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:14.3.3
-  amd64: ghcr.io/hassio-addons/base/amd64:14.3.3
-  armhf: ghcr.io/hassio-addons/base/armhf:14.3.3
-  armv7: ghcr.io/hassio-addons/base/armv7:14.3.3
-  i386: ghcr.io/hassio-addons/base/i386:14.3.3
+  aarch64: ghcr.io/hassio-addons/base/aarch64:15.0.1
+  amd64: ghcr.io/hassio-addons/base/amd64:15.0.1
+  armhf: ghcr.io/hassio-addons/base/armhf:15.0.1
+  armv7: ghcr.io/hassio-addons/base/armv7:15.0.1
+  i386: ghcr.io/hassio-addons/base/i386:15.0.1

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -1,10 +1,9 @@
 name: Remote Backup
-version: "2023.3.0"
+version: "2023.12.0"
 slug: remote_backup
 description: Automatically create and transfer HA backups using SFTP (SCP), rsync, or rclone (experimental)
 image: ikifar/remote-backup-{arch}
 url: https://addons.mathesonsteplock.ca/docs/addons/remote-backup/basic-config
-codenotary: cas@mathesonsteplock.ca
 startup: once
 boot: manual
 init: false

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -23,7 +23,7 @@ map:
   - addons
   - share
   - ssl:rw
-  - backup
+  - backup:rw
   - homeassistant_config
   - all_addon_configs
 

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -25,6 +25,7 @@ map:
   - ssl:rw
   - backup
   - homeassistant_config
+  - all_addon_configs
 
 options:
   remote_host: null

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -7,6 +7,7 @@ url: https://addons.mathesonsteplock.ca/docs/addons/remote-backup/basic-config
 startup: once
 boot: manual
 init: false
+apparmor: false
 arch:
   - aarch64
   - amd64
@@ -18,11 +19,12 @@ hassio_api: true
 hassio_role: manager
 homeassistant_api: true
 map:
-  - config
+  - addon_config:rw
   - addons
   - share
-  - ssl
+  - ssl:rw
   - backup
+  - homeassistant_config
 
 options:
   remote_host: null

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -217,7 +217,7 @@ function rsync-folders {
         return "${__BASHIO_EXIT_OK}"
     fi
 
-    local -r folders="/homeassistant_config /addons /backup /share /ssl /all_addon_configs /media" # put directories without trailing slash
+    local -r folders="/addons /all_addon_configs /backup /config /homeassistant_config /media /share /ssl" # put directories without trailing slash
     local -r rsync_url="${REMOTE_USER}@${REMOTE_HOST}:$(bashio::config 'rsync_rootfolder')"
     local flags="-a -r ${DEBUG_FLAG:-}"
 

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -198,7 +198,7 @@ function rsync-folders {
         return "${__BASHIO_EXIT_OK}"
     fi
 
-    local -r folders="/config /addons /backup /share /ssl" # put directories without trailing slash
+    local -r folders="/homeassistant_config /addons /backup /share /ssl /all_addon_configs /media" # put directories without trailing slash
     local -r rsync_url="${REMOTE_USER}@${REMOTE_HOST}:$(bashio::config 'rsync_rootfolder')"
     local flags="-a -r ${DEBUG_FLAG:-}"
 

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -74,7 +74,7 @@ function add-ssh-key {
     mkdir -p ${SSH_HOME} || bashio::log.error "Failed to create .ssh directory!"
     if bashio::config.has_value "remote_key"; then
         (
-            cp "/ssl/$(bashio::config 'remote_key')" "${SSH_HOME}/id_rsa"
+            cp "/config/$(bashio::config 'remote_key')" "${SSH_HOME}/id_rsa"
             ssh-keygen -y -f ${SSH_HOME}/id_rsa > ${SSH_HOME}/id_rsa.pub
             chmod 600 "${SSH_HOME}/id_rsa"
             chmod 644 "${SSH_HOME}/id_rsa.pub"
@@ -82,9 +82,9 @@ function add-ssh-key {
     fi
 
     # copy known_hosts if available
-    if bashio::fs.file_exists "/ssl/known_hosts"; then
-      bashio::log.debug "Using existing /ssl/known_hosts file."
-      cp "/ssl/known_hosts" "${SSH_HOME}/known_hosts" \
+    if bashio::fs.file_exists "/config/known_hosts"; then
+      bashio::log.debug "Using existing /config/known_hosts file."
+      cp "/config/known_hosts" "${SSH_HOME}/known_hosts" \
           || bashio::log.error "Failed to copy known_hosts file!"
     else
       bashio::log.warning "Missing known_hosts file! Retrieving public key of remote host ${REMOTE_HOST}."
@@ -236,7 +236,7 @@ function rclone-backups {
     (
         cd /backup/
         mkdir -p ~/.config/rclone/
-        cp -a /ssl/rclone.conf ~/.config/rclone/rclone.conf
+        cp -a /config/rclone.conf ~/.config/rclone/rclone.conf
     ) || bashio::log.error "Failed to prepare rclone configuration!"
 
     if bashio::config.true "rclone_copy"; then

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -15,7 +15,7 @@ configuration:
     description: Password to be used for authentication with remote server
   remote_key:
     name: SSH private key
-    description: SSH private key file to be used for authentication with remote server. The key must be stored in the directory 'ssl' of Home Assistant.
+    description: SSH private key file to be used for authentication with remote server. The key must be stored in the directory 'addon_config/remote_backup' of Home Assistant.
   remote_host_key_algorithms:
     name: Host key algorithms
     description: Can be used to enable further (legacy) algorithms for authentication  

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -15,7 +15,7 @@ configuration:
     description: Password to be used for authentication with remote server
   remote_key:
     name: SSH private key
-    description: SSH private key file to be used for authentication with remote server. The key must be stored in the directory 'addon_config/remote_backup' of Home Assistant.
+    description: SSH private key file to be used for authentication with remote server. The key must be stored in the directory 'addon_configs/3490a758_remote_backup' of Home Assistant.
   remote_host_key_algorithms:
     name: Host key algorithms
     description: Can be used to enable further (legacy) algorithms for authentication  


### PR DESCRIPTION
- ⬆️ Bump base image to 15.0.1 from 13.1.3
- **Breaking Change** - Switch from `/ssl` to `addon_configs/3490a758_remote_backup` for config directory (migration should be automatic)
- Temporarily disable `apparmor` to fix #119
- Drop CodeNotary signing in favor of cosign

**Full Changelog**: https://github.com/ikifar2012/remote-backup-addon/compare/2023.3.0...2023.12.0