### PR TITLE
✨ Update backup name format to include custom delimiter

### DIFF
--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -34,6 +34,7 @@ options:
   remote_key: ""
   backup_friendly_name: true
   backup_custom_prefix: Automated backup
+  backup_custom_delimiter: "_"
   backup_keep_local: "all"
   ssh_enabled: true
   ssh_remote_directory: "hassio-backup"
@@ -54,6 +55,7 @@ schema:
   remote_host_key_algorithms: str?
   backup_friendly_name: bool?
   backup_custom_prefix: str?
+  backup_custom_delimiter: str?
   backup_exclude_folders:
     - match(^[A-Za-z0-9_\-\.\*\/\?\+\\ ]*$)?
   backup_exclude_addons:

--- a/remote-backup/config.yaml
+++ b/remote-backup/config.yaml
@@ -33,7 +33,7 @@ options:
   remote_user: null
   remote_key: ""
   backup_friendly_name: true
-  backup_custom_prefix: Automated backup
+  backup_custom_prefix: Automated_backup
   backup_custom_delimiter: "_"
   backup_keep_local: "all"
   ssh_enabled: true

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -50,7 +50,7 @@ function run_setup {
 
 }
 # script global shortcuts
-declare -r BACKUP_NAME="$(bashio::config 'backup_custom_prefix' '') $(date +'%Y-%m-%d %H-%M')"
+declare -r BACKUP_NAME="$(bashio::config 'backup_custom_prefix' '')$(bashio::config 'backup_custom_delimiter' '_')$(date +'%Y-%m-%d %H-%M')"
 declare -r SSH_HOME="${HOME}/.ssh"
 
 function set-debug-level {

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -18,12 +18,16 @@ configuration:
     description: SSH private key file to be used for authentication with remote server. The key must be stored in the directory 'addon_configs/3490a758_remote_backup' of Home Assistant.
   remote_host_key_algorithms:
     name: Host key algorithms
-    description: Can be used to enable further (legacy) algorithms for authentication  
+    description: Can be used to enable further (legacy) algorithms for authentication
   backup_friendly_name:
     name: Friendly name
     description: Rename the backup on the destination server to match the name in the Home Assistant UI
   backup_custom_prefix:
     name: Custom backup name prefix
+    description: Prefix to be used for the backup name
+  backup_custom_delimiter:
+    name: Custom backup name delimiter
+    description: Delimiter to be used for the backup name between the prefix and the timestamp
   backup_exclude_folders:
     name: Folder to exclude from backup
     description: valid options are addons/local, homeassistant, media, share, ssl, all_addon_configs


### PR DESCRIPTION
This pull request includes changes to the `remote-backup` configuration and script to introduce a new custom delimiter for backup names. The most important changes are:

### Configuration updates:
* [`remote-backup/config.yaml`](diffhunk://#diff-221abb96abe8fa4de29731f3f241cd224d3a84212b1ee5014413b59464efe31bR37): Added `backup_custom_delimiter` option to the `options` section.
* [`remote-backup/config.yaml`](diffhunk://#diff-221abb96abe8fa4de29731f3f241cd224d3a84212b1ee5014413b59464efe31bR58): Updated the `schema` section to include the new `backup_custom_delimiter` option.

### Script updates:
* [`remote-backup/run.sh`](diffhunk://#diff-a6fffe7a4c21d37ee7e590b1cbc2d907e82a749d6a2d58113344afd1a30ba70fL53-R53): Modified the `BACKUP_NAME` declaration to include the new `backup_custom_delimiter` in the backup name format.

### Related issue
* Addresses recommendation in #166 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a customizable delimiter option for backup naming.
	- Enhanced backup name configuration flexibility.

- **Documentation**
	- Updated configuration descriptions for backup settings.
	- Clarified purpose of backup name prefix and delimiter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->