### PR TITLE
⬆️Update Descriptions

### DIFF
--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -27,7 +27,7 @@ configuration:
     description: Prefix to be used for the backup name
   backup_custom_delimiter:
     name: Custom backup name delimiter
-    description: Delimiter to be used for the backup name between the prefix and the timestamp
+    description: Allows you to change the delimiter between the prefix and the date of the snapshot, by default this is set to `_`
   backup_exclude_folders:
     name: Folder to exclude from backup
     description: valid options are addons/local, homeassistant, media, share, ssl, all_addon_configs

--- a/remote-backup/translations/en.yaml
+++ b/remote-backup/translations/en.yaml
@@ -36,7 +36,7 @@ configuration:
     description: Give the addons slug which equals the addon hostname using '_' instead of '-', e.g. core_mariadb
   backup_keep_local:
     name: Local backups to keep
-    description: default is 'all', give a number for the last x backups to keep or empty to immediately remove created backups after copying.
+    description: default is 'all', give a number for the last x backups to keep or 'null' to immediately remove created backups after copying.
   backup_password:
     name: Password for protected backup
   ssh_enabled:


### PR DESCRIPTION
This pull request includes updates to the `remote-backup/translations/en.yaml` file to clarify descriptions for backup configuration options. The changes improve the readability and understanding of the configuration settings.

Improvements to backup configuration descriptions:

* [`remote-backup/translations/en.yaml`](diffhunk://#diff-d07a3eb801ccb43e8f96eaebb4e3bb7191299e92065f9f608211bfaf2c8551d3L30-R30): Updated the description for `backup_custom_delimiter` to clarify that it allows changing the delimiter between the prefix and the date of the snapshot, with the default set to `_`.
* [`remote-backup/translations/en.yaml`](diffhunk://#diff-d07a3eb801ccb43e8f96eaebb4e3bb7191299e92065f9f608211bfaf2c8551d3L39-R39): Updated the description for `backup_keep_local` to specify that the default is 'all', and to use 'null' to immediately remove created backups after copying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the clarity of backup configuration options.
  - Updated the delimiter option description to explicitly mention the default separator between the prefix and the snapshot date.
  - Revised the backup retention description to indicate that using 'null' will remove backups immediately after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->